### PR TITLE
Windows-specific console size configuration removed to work on mac

### DIFF
--- a/Z00bfuscator/Program.cs
+++ b/Z00bfuscator/Program.cs
@@ -74,8 +74,10 @@ namespace Z00bfuscator
             var configuration = asm.GetCustomAttribute<AssemblyConfigurationAttribute>()?.Configuration;
             var informationalVersion = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
-            Console.WindowWidth = 140;
-            Console.BufferHeight = 5000;
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)) {
+                Console.WindowWidth = 140;
+                Console.BufferHeight = 5000;
+            }
             Console.Title = string.Format("{0} {1} ({2}) [{3}] {4}",
                 title,
                 version,


### PR DESCRIPTION
**Changes:**

Commented out the original code setting console window width and buffer height.
Removed platform-specific logic for setting console size.
**Reasoning:**

The previous code attempted to set the console size directly, which might not work consistently across different operating systems.
This change ensures the application behaves as expected on platforms other than Windows (specifically, this PR focuses on Mac compatibility).